### PR TITLE
Defer explanation costs

### DIFF
--- a/src/approx_bitset.rs
+++ b/src/approx_bitset.rs
@@ -1,0 +1,57 @@
+use egg::Id;
+use hashbrown::HashSet;
+use std::fmt::Debug;
+
+type Elt = u128;
+pub const BITS: usize = Elt::BITS as usize;
+
+#[derive(Debug)]
+pub(crate) struct ApproxBitSet(Elt);
+
+pub(crate) trait IdSet: Debug {
+    fn empty() -> Self;
+
+    fn insert(&mut self, val: Id);
+
+    fn may_contain(&self, val: Id) -> bool;
+
+    fn might_confuse(id1: Id, id2: Id) -> bool;
+}
+
+impl IdSet for ApproxBitSet {
+    fn empty() -> Self {
+        ApproxBitSet(0)
+    }
+
+    fn insert(&mut self, val: Id) {
+        let shift = usize::from(val) % BITS;
+        self.0 |= 1 << shift
+    }
+
+    fn may_contain(&self, val: Id) -> bool {
+        let shift = usize::from(val) % BITS;
+        self.0 & (1 << shift) != 0
+    }
+
+    fn might_confuse(id1: Id, id2: Id) -> bool {
+        usize::from(id1) % BITS == usize::from(id2) % BITS
+    }
+}
+
+impl IdSet for HashSet<Id> {
+    fn empty() -> Self {
+        HashSet::default()
+    }
+
+    fn insert(&mut self, val: Id) {
+        self.insert(val);
+    }
+
+    fn may_contain(&self, val: Id) -> bool {
+        self.contains(&val)
+    }
+
+    fn might_confuse(id1: Id, id2: Id) -> bool {
+        id1 == id2
+    }
+}

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -46,7 +46,7 @@ impl Language for SymbolLang {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EGraph<D> {
     inner: RawEGraph<SymbolLang, D, UndoLog>,
     explain: Explain,
@@ -139,8 +139,8 @@ impl<D> EGraph<D> {
 
     pub fn explain_equivalence(&self, id1: Id, id2: Id, res: &mut LSet, negate: bool) {
         self.explain
-            .with_raw_egraph(&self.inner)
-            .explain_equivalence(id1, id2, res, negate)
+            .promote(&self.inner, res, negate)
+            .explain_equivalence(id1, id2)
     }
 
     pub fn is_clean(&self) -> bool {

--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -85,7 +85,10 @@ impl<D> EGraph<D> {
             // so we do not need to distinguish between nodes that are
             // equivalent modulo ground equalities
             |_, id, _| Some(id),
-            |this, id1, id2| this.explain.union(id1, id2, Justification::CONGRUENCE),
+            |this, existing_id, new_id| {
+                this.explain
+                    .union(existing_id, Justification::CONGRUENCE, existing_id, new_id)
+            },
             |this, id, _| {
                 this.explain.add(id);
                 mk_data(id)
@@ -102,7 +105,12 @@ impl<D> EGraph<D> {
     ) {
         self.inner.raw_union(id1, id2, |info| {
             merge(info.data1, info.data2);
-            self.explain.union(id1, id2, justification)
+            let (old_id, new_id) = if info.swapped_ids {
+                (id1, id2)
+            } else {
+                (id2, id1)
+            };
+            self.explain.union(info.id2, justification, old_id, new_id)
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod approx_bitset;
 mod egraph;
 mod euf;
 mod explain;


### PR DESCRIPTION
We were previously using the O(k) explain implementation from [https://www.cs.upc.edu/~oliveras/rta05.pdf](https://www.cs.upc.edu/~oliveras/rta05.pdf) 2.2, but I though it would be worth trying the O(k log n) implementation from 2.1 since it makes unions cheaper.