### PR TITLE
Improve union argument order

### DIFF
--- a/src/euf.rs
+++ b/src/euf.rs
@@ -370,7 +370,7 @@ impl EUF {
                 });
             let tid = self.id_for_bool(true);
             self.egraph
-                .union(eq_self, tid, Justification::NOOP, |_, _| {
+                .union(tid, eq_self, Justification::NOOP, |_, _| {
                     self.bool_class_history.push(MergeInfo::Both(true))
                 })
         }


### PR DESCRIPTION
`egg` currently decides which of two ids being union-ed should be the root based on which has more parents. This works well enough if ids have parents, but degenerates to deciding based on argument order if neither id has a parent. Since the current implementations represents possible equalities as parent nodes most nodes have parents except the equalities themselves which makes the order they are union-ed important. This fixes that order to avoid long chains in the union find without path compression.