### PR TITLE
Make literal picker independent of theory explanation order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "batsat"
 version = "0.5.0"
-source = "git+https://github.com/dewert99/batsat?branch=deterministic#1a0b923966c4b1ec389e56876b75af397e1f5b2a"
+source = "git+https://github.com/dewert99/batsat?branch=deterministic#dbe576ee3ed031fdf16b295dc859b42082be8720"
 dependencies = [
  "bit-vec",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "batsat"
 version = "0.5.0"
-source = "git+https://github.com/dewert99/batsat?branch=deterministic#b14421875b980af4fbea2a683497ec2976a16c4c"
+source = "git+https://github.com/dewert99/batsat?branch=deterministic#1a0b923966c4b1ec389e56876b75af397e1f5b2a"
 dependencies = [
  "bit-vec",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "batsat"
 version = "0.5.0"
-source = "git+https://github.com/c-cube/batsat?branch=master#0419daa281dce77fd6317c595ba13776548ea7a4"
+source = "git+https://github.com/dewert99/batsat?branch=deterministic#e66c5c9ccb60c53cecf2d20733eed2e27fe46035"
 dependencies = [
  "bit-vec",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "batsat"
 version = "0.5.0"
-source = "git+https://github.com/dewert99/batsat?branch=deterministic#9972854c3d65e6e82edb94bef061c16467d5d48a"
+source = "git+https://github.com/dewert99/batsat?branch=deterministic#288548b1169bf5713088c61dc9dc3f8a9a6b08c2"
 dependencies = [
  "bit-vec",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "batsat"
 version = "0.5.0"
-source = "git+https://github.com/dewert99/batsat?branch=deterministic#e66c5c9ccb60c53cecf2d20733eed2e27fe46035"
+source = "git+https://github.com/dewert99/batsat?branch=deterministic#b14421875b980af4fbea2a683497ec2976a16c4c"
 dependencies = [
  "bit-vec",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "batsat"
 version = "0.5.0"
-source = "git+https://github.com/dewert99/batsat?branch=deterministic#dbe576ee3ed031fdf16b295dc859b42082be8720"
+source = "git+https://github.com/dewert99/batsat?branch=deterministic#c3a8b38e7251adea268ea073480a92a12b2a61fc"
 dependencies = [
  "bit-vec",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "batsat"
 version = "0.5.0"
-source = "git+https://github.com/dewert99/batsat?branch=deterministic#c3a8b38e7251adea268ea073480a92a12b2a61fc"
+source = "git+https://github.com/dewert99/batsat?branch=deterministic#9972854c3d65e6e82edb94bef061c16467d5d48a"
 dependencies = [
  "bit-vec",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 name = "batsat"
 version = "0.5.0"
-source = "git+https://github.com/dewert99/batsat?branch=deterministic#288548b1169bf5713088c61dc9dc3f8a9a6b08c2"
+source = "git+https://github.com/dewert99/batsat?branch=deterministic#f888533434a794302e5dbd16d2aa00b8a82ebb76"
 dependencies = [
  "bit-vec",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-batsat = { git = "https://github.com/c-cube/batsat", branch = "master", features = ["logging"] }
+batsat = { git = "https://github.com/dewert99/batsat", branch = "deterministic", features = ["logging"] }
 egg = {git = "https://github.com/dewert99/egg", branch = "semi-persistent"}
 hashbrown = "0.14.3"
 log = "0.4.20"


### PR DESCRIPTION
While working on #11 I noticed that some of the performance changes were caused by differences in the literal picking order which themselves were cause by the explanations having different orders (even though they were always the same set). For this PR I modified batsat's literal picker to ignore the explanation order so that #11 could be better compared. 