### PR TITLE
Optimize assert

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -426,6 +426,15 @@ impl ExpParser for AssertExpParser {
             (ExpKind::Not, pol) => {
                 p.parse_assert(rest.next_full()?, !pol)?;
             }
+            (ExpKind::Eq, false) => {
+                let exp1 = p.parse_exp(rest.next()?)?;
+                let (id1, sort1) = p.core.id_sort(exp1);
+                rest.map_full(|x| {
+                    let id2 = p.parse_id(x?, sort1)?;
+                    Ok(p.core.assert_raw_eq(id1, id2))
+                })
+                .collect::<Result<()>>()?;
+            }
             (_, pol) => {
                 let exp = BaseExpParser.parse(p, f, rest)?;
                 match exp.as_bool() {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -11,8 +11,7 @@ use hashbrown::HashMap;
 use log::debug;
 use std::borrow::BorrowMut;
 use std::fmt::{Debug, Display, Formatter};
-use std::ops::Not;
-
+use std::ops::{BitXor, Not};
 /// The main solver structure including the sat solver and egraph.
 ///
 /// It allows constructing and asserting expressions [`Exp`] within the solver
@@ -100,6 +99,17 @@ impl Not for BoolExp {
         match self {
             BoolExp::Const(b) => BoolExp::Const(!b),
             BoolExp::Unknown(lit) => BoolExp::Unknown(!lit),
+        }
+    }
+}
+
+impl BitXor<bool> for BoolExp {
+    type Output = BoolExp;
+
+    fn bitxor(self, rhs: bool) -> Self::Output {
+        match self {
+            BoolExp::Const(b) => BoolExp::Const(b ^ rhs),
+            BoolExp::Unknown(lit) => BoolExp::Unknown(lit ^ rhs),
         }
     }
 }

--- a/tests/smt2/push-pop.stdout
+++ b/tests/smt2/push-pop.stdout
@@ -10,12 +10,12 @@ sat
 (
  (define-fun a () S S!val!2)
  (define-fun b () S S!val!2)
- (define-fun c () S2 S2!val!7)
+ (define-fun c () S2 S2!val!5)
  (define-fun f ((x!0 S)) Bool
   (ite (= x!0 S!val!2) true
    f!default))
  (define-fun g ((x!0 S2)) S
-  (ite (= x!0 S2!val!7) S!val!8
+  (ite (= x!0 S2!val!5) S!val!6
    g!default))
 )
 unsat
@@ -24,10 +24,10 @@ sat
 (
  (define-fun a () S S!val!2)
  (define-fun b () S S!val!2)
- (define-fun c () S S!val!7)
+ (define-fun c () S S!val!5)
  (define-fun f ((x!0 S)) Bool
   (ite (= x!0 S!val!2) true
-  (ite (= x!0 S!val!7) false
+  (ite (= x!0 S!val!5) false
    f!default)))
 )
 unsat


### PR DESCRIPTION
Specialize parsing of `assert` statements, (eg: `(assert (and a b))` => `(assert a)`, `(assert b)`