### PR TITLE
Don't use `Cell` in `Explain`

### DIFF
--- a/src/egraph.rs
+++ b/src/egraph.rs
@@ -309,7 +309,7 @@ impl EGraph<EClass> {
     }
 
     pub fn explain_equivalence(
-        &self,
+        &mut self,
         id1: Id,
         id2: Id,
         res: &mut LSet,


### PR DESCRIPTION
I somehow though `Theory::explain_propagation` only got a shared reference, so I used `Cell`s to reuse memory for scratch `Vec`s, but since this isn't true we can remove the `Cell`s.