### PR TITLE
Optimize `gen_sym` in release mode

### DIFF
--- a/src/euf.rs
+++ b/src/euf.rs
@@ -673,6 +673,12 @@ impl EUFInner {
     pub fn has_parents(&self, id: Id) -> bool {
         self.egraph[id].parents().len() > 0
     }
+
+    /// Returns an `Id` one past the last `Id`, such that an `Id` `id` is valid iff
+    /// `id < self.len_id()`
+    pub fn len_id(&self) -> Id {
+        Id::from(self.egraph.number_of_uncanonical_nodes())
+    }
 }
 
 #[perfect_derive(Default)]

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -101,6 +101,7 @@ impl SymbolInfo {
             panic!("Too many symbols");
         }
         let res = res as u32;
+        #[cfg(debug_assertions)] // this is only useful for logging
         write!(&mut self.symbol_data, "{name}|{res}").unwrap();
         self.symbol_indices.push(self.symbol_data.len());
         Symbol(res)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod junction;
 mod parser;
 pub mod parser_core;
 mod solver;
+mod sp_insert_map;
 mod theory;
 mod util;
 

--- a/src/sp_insert_map.rs
+++ b/src/sp_insert_map.rs
@@ -1,0 +1,56 @@
+use crate::util::DefaultHashBuilder;
+use core::fmt::Debug;
+use core::hash::{BuildHasher, Hash};
+use hashbrown::hash_table::Entry;
+use hashbrown::HashTable;
+use no_std_compat::prelude::v1::*;
+use perfect_derive::perfect_derive;
+
+#[perfect_derive(Default)]
+pub(crate) struct SPInsertMap<K, V> {
+    map: HashTable<(K, V)>,
+    hasher: DefaultHashBuilder,
+    pub(crate) entries: Vec<(u64, V)>,
+}
+
+impl<K: Hash + Eq + Debug, V: Hash + Ord + Copy + Debug> SPInsertMap<K, V> {
+    /// Gets the value associated with `k` or calls `v` to create a new one
+    /// If called `v` should return a value larger than all the values in the map
+    pub(crate) fn get_or_insert(&mut self, k: K, mut v: impl FnMut() -> V) -> V {
+        let hash = self.hasher.hash_one(&k);
+        match self
+            .map
+            .entry(hash, |(k2, _)| *k2 == k, |k2| self.hasher.hash_one(k2))
+        {
+            Entry::Occupied(occ) => occ.into_mut().1,
+            Entry::Vacant(vac) => {
+                let v = v();
+                if let Some((_, last_v)) = self.entries.last() {
+                    debug_assert!(v >= *last_v);
+                }
+                self.entries.push((hash, v));
+                vac.insert((k, v)).into_mut().1
+            }
+        }
+    }
+
+    /// Removes all values at that are at least `lowest_to_remove`
+    pub(crate) fn remove_after(&mut self, lowest_to_remove: V) {
+        while let Some((hash, v)) = self.entries.pop() {
+            if v < lowest_to_remove {
+                self.entries.push((hash, v));
+                return;
+            } else {
+                self.map
+                    .find_entry(hash, |(_, v2)| *v2 == v)
+                    .unwrap()
+                    .remove();
+            }
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+        self.map.clear();
+    }
+}


### PR DESCRIPTION
Don't give names to symbols created with `gen_sym`. This makes logging worse but improves performance.